### PR TITLE
Fix PDF worker CMap file loading

### DIFF
--- a/src/js/common/pdf-worker.js
+++ b/src/js/common/pdf-worker.js
@@ -74,7 +74,7 @@ export class PDFWorker {
 						const response = await fetch(this.config.pdfReaderCMapsURL + message.data + '.bcmap');
 						const arrayBuffer = await response.arrayBuffer();
 						respData = {
-							compressionType: 1,
+							isCompressed: true,
 							cMapData: new Uint8Array(arrayBuffer)
 						};
 					}


### PR DESCRIPTION
PDF.js changed the property name at some point, which prevents CMap files from loading properly.